### PR TITLE
Fix generate listview with parameter

### DIFF
--- a/commands/listview.js
+++ b/commands/listview.js
@@ -24,8 +24,13 @@ module.exports = async function (context) {
   const typeDataMessage = 'How will your data be presented on this listview?'
   const typeDataChoices = ['Single', 'Sectioned']
 
-  // pick one
+  // get type
   let type = parameters.options.type
+
+  // get dataType
+  let dataType = parameters.options.dataType
+
+  // only prompt if type is not defined
   if (!type) {
     // as question 1
     const answers = await context.prompt.ask({


### PR DESCRIPTION
Running `ignite g listview TestRow --type=Row` fails with an exception because a variable is undefined. This change defines the variable. It also makes it so that `--dataType` can be passed as a parameter.