### PR TITLE
no rehydration by default - opt in only

### DIFF
--- a/boilerplate/App/Config/ReduxPersist.js
+++ b/boilerplate/App/Config/ReduxPersist.js
@@ -1,9 +1,10 @@
 import immutablePersistenceTransform from '../Services/ImmutablePersistenceTransform'
 import { AsyncStorage } from 'react-native'
 
+// More info here:  https://shift.infinite.red/shipping-persistant-reducers-7341691232b1
 const REDUX_PERSIST = {
-  active: true,
-  reducerVersion: '4',
+  active: false,
+  reducerVersion: '1.0',
   storeConfig: {
     storage: AsyncStorage,
     blacklist: ['login', 'search'], // reducer keys that you do NOT want stored to persistence here


### PR DESCRIPTION
I had someone complain in community.infinite.red and when I found their bug, it was because they didn't know it was rehydrating.  I think this is the second or third person to have this issue.   Let's turn this off bey default.  Next step, make it an opt-in plugin.