### PR TITLE
[Do not merge yet] Supports new customized paths in Ignite

### DIFF
--- a/boilerplate/ignite.json.ejs
+++ b/boilerplate/ignite.json.ejs
@@ -1,5 +1,7 @@
 {
   "createdWith": "<%= props.igniteVersion %>",
   "examples": "classic",
-  "navigation": "react-navigation"
+  "navigation": "react-navigation",
+  "generators": {},
+  "paths": {}
 }

--- a/commands/component.js
+++ b/commands/component.js
@@ -16,7 +16,6 @@ module.exports = async function (context) {
   const name = pascalCase(parameters.first)
   const props = { name }
   const componentPath = `${paths.app}/${paths.components}`
-  console.dir(paths, {colors: true})
   const componentStylesPath = `${componentPath}/Styles`
   const testsPath = `${paths.tests}/${paths.components}`
 

--- a/commands/component.js
+++ b/commands/component.js
@@ -5,7 +5,7 @@ module.exports = async function (context) {
   const { parameters, strings, print, ignite } = context
   const { pascalCase, isBlank } = strings
   const config = ignite.loadIgniteConfig()
-  const { tests } = config
+  const { paths, tests } = config
 
   // validation
   if (isBlank(parameters.first)) {
@@ -17,19 +17,24 @@ module.exports = async function (context) {
   // read some configuration
   const name = pascalCase(parameters.first)
   const props = { name }
+  const componentPath = `${paths.app}/${paths.components}`
+  console.dir(paths, {colors: true})
+  const componentStylesPath = `${componentPath}/Styles`
+  const testsPath = `${paths.tests}/${paths.components}`
+
   const jobs = [
     {
       template: 'component.ejs',
-      target: `App/Components/${name}.js`
+      target: `${componentPath}/${name}.js`
     },
     {
       template: 'component-style.ejs',
-      target: `App/Components/Styles/${name}Style.js`
+      target: `${componentStylesPath}/${name}Style.js`
     },
     tests === 'ava' &&
       {
         template: 'component-test.ejs',
-        target: `Test/Components/${name}Test.js`
+        target: `${testsPath}/${name}Test.js`
       }
   ]
 

--- a/commands/component.js
+++ b/commands/component.js
@@ -2,10 +2,8 @@
 
 module.exports = async function (context) {
   // grab some features
-  const { parameters, strings, print, ignite } = context
-  const { pascalCase, isBlank } = strings
-  const config = ignite.loadIgniteConfig()
-  const { paths, tests } = config
+  const { parameters, print, ignite, strings: { pascalCase, isBlank } } = context
+  const { paths, tests } = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {

--- a/commands/container.js
+++ b/commands/container.js
@@ -6,7 +6,7 @@ module.exports = async function (context) {
   // grab some features
   const { parameters, strings, print, ignite, filesystem } = context
   const { pascalCase, isBlank } = strings
-  const config = ignite.loadIgniteConfig()
+  const { navigation, paths } = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {
@@ -17,15 +17,18 @@ module.exports = async function (context) {
 
   const name = pascalCase(parameters.first)
   const props = { name }
+  const containerPath = `${paths.app}/${paths.containers}`
+  const containerStylesPath = `${containerPath}/Styles`
+  const navigationPath = `${paths.app}/${paths.navigation}`
 
   const jobs = [
     {
       template: 'container.ejs',
-      target: `App/Containers/${name}.js`
+      target: `${containerPath}/${name}.js`
     },
     {
       template: 'container-style.ejs',
-      target: `App/Containers/Styles/${name}Style.js`
+      target: `${containerStylesPath}/${name}Style.js`
     }
   ]
 
@@ -33,10 +36,10 @@ module.exports = async function (context) {
 
   // if using `react-navigation` go the extra step
   // and insert the container into the nav router
-  if (config.navigation === 'react-navigation') {
+  if (navigation === 'react-navigation') {
     const containerName = name
-    const appNavFilePath = `${process.cwd()}/App/Navigation/AppNavigation.js`
-    const importToAdd = `import ${containerName} from '../Containers/${containerName}'`
+    const appNavFilePath = `${process.cwd()}/${navigationPath}/AppNavigation.js`
+    const importToAdd = `import ${containerName} from '../${paths.containers}/${containerName}'`
     const routeToAdd = `  ${containerName}: { screen: ${containerName} },`
 
     if (!filesystem.exists(appNavFilePath)) {

--- a/commands/listview.js
+++ b/commands/listview.js
@@ -17,7 +17,7 @@ module.exports = async function (context) {
 
   const name = pascalCase(parameters.first)
   const props = { name }
-  const containerPath = `${paths.app}/${paths.container}`
+  const containerPath = `${paths.app}/${paths.containers}`
   const containerStylesPath = `${containerPath}/Styles`
   const navigationPath = `${paths.app}/${paths.navigation}`
 

--- a/commands/listview.js
+++ b/commands/listview.js
@@ -6,7 +6,7 @@ module.exports = async function (context) {
   // grab some features
   const { print, parameters, strings, ignite, filesystem } = context
   const { pascalCase, isBlank } = strings
-  const config = ignite.loadIgniteConfig()
+  const { navigation, paths } = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {
@@ -17,6 +17,9 @@ module.exports = async function (context) {
 
   const name = pascalCase(parameters.first)
   const props = { name }
+  const containerPath = `${paths.app}/${paths.container}`
+  const containerStylesPath = `${containerPath}/Styles`
+  const navigationPath = `${paths.app}/${paths.navigation}`
 
   // which type of layout?
   const typeMessage = 'What kind of ListView would you like to generate?'
@@ -63,11 +66,11 @@ module.exports = async function (context) {
   const jobs = [
     {
       template: `${componentTemplate}.ejs`,
-      target: `App/Containers/${name}.js`
+      target: `${containerPath}/${name}.js`
     },
     {
       template: `${styleTemplate}.ejs`,
-      target: `App/Containers/Styles/${name}Style.js`
+      target: `${containerStylesPath}/${name}Style.js`
     }
   ]
 
@@ -75,10 +78,10 @@ module.exports = async function (context) {
 
   // if using `react-navigation` go the extra step
   // and insert the screen into the nav router
-  if (config.navigation === 'react-navigation') {
+  if (navigation === 'react-navigation') {
     const screenName = `${name}`
-    const appNavFilePath = `${process.cwd()}/App/Navigation/AppNavigation.js`
-    const importToAdd = `import ${screenName} from '../Containers/${screenName}'`
+    const appNavFilePath = `${process.cwd()}/${navigationPath}/AppNavigation.js`
+    const importToAdd = `import ${screenName} from '../${paths.components}/${screenName}'`
     const routeToAdd = `  ${screenName}: { screen: ${screenName} },`
 
     if (!filesystem.exists(appNavFilePath)) {

--- a/commands/redux.js
+++ b/commands/redux.js
@@ -4,7 +4,7 @@ module.exports = async function (context) {
   // grab some features
   const { parameters, ignite, strings, print } = context
   const { isBlank, pascalCase } = strings
-  const config = ignite.loadIgniteConfig()
+  const { tests, paths } = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {
@@ -16,11 +16,11 @@ module.exports = async function (context) {
   const name = pascalCase(parameters.first)
   const props = { name }
 
-  const jobs = [{ template: `redux.ejs`, target: `App/Redux/${name}Redux.js` }]
-  if (config.tests) {
+  const jobs = [{ template: `redux.ejs`, target: `${paths.app}/${paths.redux || 'Redux'}/${name}Redux.js` }]
+  if (tests) {
     jobs.push({
-      template: `redux-test-${config.tests}.ejs`,
-      target: `Tests/Redux/${name}ReduxTest.js`
+      template: `redux-test-${tests}.ejs`,
+      target: `${paths.app}/${paths.redux || 'Redux'}/${name}ReduxTest.js`
     })
   }
 

--- a/commands/saga.js
+++ b/commands/saga.js
@@ -4,8 +4,7 @@ module.exports = async function (context) {
   // grab some features
   const { parameters, ignite, print, strings } = context
   const { pascalCase, isBlank } = strings
-  const config = ignite.loadIgniteConfig()
-  const { tests } = config
+  const { tests, paths } = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {
@@ -17,11 +16,11 @@ module.exports = async function (context) {
   const name = pascalCase(parameters.first)
   const props = { name }
 
-  const jobs = [{ template: `saga.ejs`, target: `App/Sagas/${name}Sagas.js` }]
+  const jobs = [{ template: `saga.ejs`, target: `${paths.app}/${paths.sagas || 'Sagas'}/${name}Sagas.js` }]
   if (tests) {
     jobs.push({
       template: `saga-test-${tests}.ejs`,
-      target: `Tests/Saga/${name}SagaTest.js`
+      target: `${paths.tests}/${paths.sagas || 'Sagas'}/${name}SagaTest.js`
     })
   }
 

--- a/commands/screen.js
+++ b/commands/screen.js
@@ -17,7 +17,7 @@ module.exports = async function (context) {
 
   const name = pascalCase(parameters.first)
   const props = { name }
-  const containerPath = `${paths.app}/${paths.container}`
+  const containerPath = `${paths.app}/${paths.containers}`
   const containerStylesPath = `${containerPath}/Styles`
 
   const jobs = [

--- a/commands/screen.js
+++ b/commands/screen.js
@@ -6,7 +6,7 @@ module.exports = async function (context) {
   // grab some features
   const { parameters, print, strings, ignite, filesystem } = context
   const { pascalCase, isBlank } = strings
-  const config = ignite.loadIgniteConfig()
+  const { navigation, paths } = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {
@@ -17,15 +17,17 @@ module.exports = async function (context) {
 
   const name = pascalCase(parameters.first)
   const props = { name }
+  const containerPath = `${paths.app}/${paths.container}`
+  const containerStylesPath = `${containerPath}/Styles`
 
   const jobs = [
     {
       template: `screen.ejs`,
-      target: `App/Containers/${name}Screen.js`
+      target: `${containerPath}/${name}Screen.js`
     },
     {
       template: `screen-style.ejs`,
-      target: `App/Containers/Styles/${name}ScreenStyle.js`
+      target: `${containerStylesPath}/${name}ScreenStyle.js`
     }
   ]
 
@@ -34,10 +36,10 @@ module.exports = async function (context) {
 
   // if using `react-navigation` go the extra step
   // and insert the screen into the nav router
-  if (config.navigation === 'react-navigation') {
+  if (navigation === 'react-navigation') {
     const screenName = `${name}Screen`
-    const appNavFilePath = `${process.cwd()}/App/Navigation/AppNavigation.js`
-    const importToAdd = `import ${screenName} from '../Containers/${screenName}'`
+    const appNavFilePath = `${process.cwd()}/${paths.app}/Navigation/AppNavigation.js`
+    const importToAdd = `import ${screenName} from '../${paths.containers}/${screenName}'`
     const routeToAdd = `  ${screenName}: { screen: ${screenName} },`
 
     if (!filesystem.exists(appNavFilePath)) {

--- a/ignite.json
+++ b/ignite.json
@@ -6,5 +6,16 @@
     "redux",
     "saga",
     "screen"
-  ]
+  ],
+  "paths": {
+    "app": "App",
+    "tests": "Tests",
+    "components": "Components",
+    "config": "Config",
+    "containers": "Containers",
+    "fixtures": "Fixtures",
+    "images": "Images",
+    "navigation": "Navigation",
+    "services": "Services"
+  }
 }


### PR DESCRIPTION
Per https://github.com/infinitered/ignite/pull/994, we may be implementing customized paths for generators via the `ignite/ignite.json` config file. This implements the required changes in these generators.

However, we have an issue, in that anyone using an old version of `ignite` will see things get generated in `undefined/undefined/MyScreen.js`.

How do we want to handle this? Detect no `paths` config and kill execution, prompting them to upgrade their Ignite version?