### PR TITLE
Adds clarification for addComponentExample usage

### DIFF
--- a/boilerplate/App/Components/DrawerButton.js
+++ b/boilerplate/App/Components/DrawerButton.js
@@ -3,7 +3,9 @@ import { Text, TouchableOpacity } from 'react-native'
 import styles from './Styles/DrawerButtonStyles'
 import ExamplesRegistry from '../Services/ExamplesRegistry'
 
-// Example
+// Note that this file (App/Components/DrawerButton) needs to be
+// imported in your app somewhere, otherwise your component won't be
+// compiled and added to the examples dev screen.
 ExamplesRegistry.addComponentExample('Drawer Button', () =>
   <DrawerButton
     text='Example left drawer button'

--- a/boilerplate/App/Components/FullButton.js
+++ b/boilerplate/App/Components/FullButton.js
@@ -3,7 +3,9 @@ import { TouchableOpacity, Text } from 'react-native'
 import styles from './Styles/FullButtonStyles'
 import ExamplesRegistry from '../Services/ExamplesRegistry'
 
-// Example
+// Note that this file (App/Components/FullButton) needs to be
+// imported in your app somewhere, otherwise your component won't be
+// compiled and added to the examples dev screen.
 ExamplesRegistry.addComponentExample('Full Button', () =>
   <FullButton
     text='Hey there'

--- a/boilerplate/App/Components/RoundedButton.js
+++ b/boilerplate/App/Components/RoundedButton.js
@@ -3,7 +3,9 @@ import { TouchableOpacity, Text } from 'react-native'
 import styles from './Styles/RoundedButtonStyles'
 import ExamplesRegistry from '../Services/ExamplesRegistry'
 
-// Example
+// Note that this file (App/Components/RoundedButton) needs to be
+// imported in your app somewhere, otherwise your component won't be
+// compiled and added to the examples dev screen.
 ExamplesRegistry.addComponentExample('Rounded Button', () =>
   <RoundedButton
     text='real buttons have curves'


### PR DESCRIPTION
There's some confusion around why a component doesn't show up in the devscreens even when registered through `addComponentExample`. This clarifies that you also need to import your component somewhere in your application.