### PR TITLE
Fix missing Screen append on screen name

### DIFF
--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -7,7 +7,7 @@ import { connect } from 'react-redux'
 // Styles
 import styles from './Styles/<%= props.name %>ScreenStyle'
 
-class <%= props.name %> extends React.Component {
+class <%= props.name %>Screen extends React.Component {
 
   render () {
     return (
@@ -31,4 +31,4 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(<%= props.name %>)
+export default connect(mapStateToProps, mapDispatchToProps)(<%= props.name %>Screen)


### PR DESCRIPTION
Seems that we were missing the appending of Screen in the generated screen file.
While it shouldn't cause any big issues, we do append `Screen` to the entered screen name in the CLI  [here](https://github.com/infinitered/ignite-ir-next/blob/master/commands/screen.js) and we do it in the 2016 boilerplate...just being consistent ;) 👍 