### PR TITLE
References current boilerplate from dirname

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -204,7 +204,7 @@ async function install (context) {
   //   * this needs to get planned a little better.
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   try {
-    await system.spawn(`ignite add ir-next ${debugFlag}`, { stdio: 'inherit' })
+    await system.spawn(`ignite add ${__dirname} ${debugFlag}`, { stdio: 'inherit' })
 
     // now run install of Ignite Plugins
     if (answers['dev-screens'] === 'Yes') {


### PR DESCRIPTION
Related to @skellock's comment here: https://github.com/infinitered/ignite/issues/985#issuecomment-296445504

This allows you to add the boilerplate plugin from a path rather than requiring it from npm.
