### PR TITLE
Add jest-snapshot tests

### DIFF
--- a/boilerplate/App/Components/DrawerButton.js
+++ b/boilerplate/App/Components/DrawerButton.js
@@ -6,6 +6,9 @@ import ExamplesRegistry from '../Services/ExamplesRegistry'
 // Note that this file (App/Components/DrawerButton) needs to be
 // imported in your app somewhere, otherwise your component won't be
 // compiled and added to the examples dev screen.
+
+// Ignore in coverage report
+/* istanbul ignore next */
 ExamplesRegistry.addComponentExample('Drawer Button', () =>
   <DrawerButton
     text='Example left drawer button'

--- a/boilerplate/App/Components/FullButton.js
+++ b/boilerplate/App/Components/FullButton.js
@@ -6,6 +6,9 @@ import ExamplesRegistry from '../Services/ExamplesRegistry'
 // Note that this file (App/Components/FullButton) needs to be
 // imported in your app somewhere, otherwise your component won't be
 // compiled and added to the examples dev screen.
+
+// Ignore in coverage report
+/* istanbul ignore next */
 ExamplesRegistry.addComponentExample('Full Button', () =>
   <FullButton
     text='Hey there'

--- a/boilerplate/App/Components/RoundedButton.js
+++ b/boilerplate/App/Components/RoundedButton.js
@@ -6,6 +6,9 @@ import ExamplesRegistry from '../Services/ExamplesRegistry'
 // Note that this file (App/Components/RoundedButton) needs to be
 // imported in your app somewhere, otherwise your component won't be
 // compiled and added to the examples dev screen.
+
+// Ignore in coverage report
+/* istanbul ignore next */
 ExamplesRegistry.addComponentExample('Rounded Button', () =>
   <RoundedButton
     text='real buttons have curves'

--- a/boilerplate/Tests/Components/AlertMessageTest.js
+++ b/boilerplate/Tests/Components/AlertMessageTest.js
@@ -1,34 +1,19 @@
+import 'react-native'
 import React from 'react'
-import { Text } from 'react-native'
 import AlertMessage from '../../App/Components/AlertMessage'
-import { shallow } from 'enzyme'
+import renderer from 'react-test-renderer'
 
-// Basic wrapper
-const wrapper = shallow(<AlertMessage title='howdy' />)
-
-test('component exists', () => {
-  expect(wrapper.length).toBe(1) // exists
+test('AlertMessage component renders correctly if show is true', () => {
+  const tree = renderer.create(<AlertMessage title='howdy' />).toJSON()
+  expect(tree).toMatchSnapshot()
 })
 
-test('component structure', () => {
-  expect(wrapper.name()).toBe('View')
-  expect(wrapper.children().length).toBe(1) // has 1 child
-  expect(wrapper.children().first().name()).toBe('View') // that child is View
-
-  const subview = wrapper.children().first()
-  expect(subview.children().length).toBe(1)
+test('AlertMessage component does not render if show is false', () => {
+  const tree = renderer.create(<AlertMessage title='howdy' show={false} />).toJSON()
+  expect(tree).toMatchSnapshot()
 })
 
-test('Has text and set properly', () => {
-  expect(wrapper.containsMatchingElement(<Text allowFontScaling={false}>HOWDY</Text>)).toBe(true)
-})
-
-test('style props are passed to top view', () => {
-  const withStyle = shallow(<AlertMessage title='howdy' style={{backgroundColor: 'red'}} />)
-  expect(withStyle.props().style[1].backgroundColor).toBe('red')
-})
-
-test('show false', () => {
-  const hidden = shallow(<AlertMessage title='howdy' show={false} />)
-  expect(hidden.children().length).toBe(0)
+test('AlertMessage component renders correctly if backgroundColor prop is set', () => {
+  const tree = renderer.create(<AlertMessage title='howdy' style={{backgroundColor: 'red'}} />).toJSON()
+  expect(tree).toMatchSnapshot()
 })

--- a/boilerplate/Tests/Components/DrawerButtonTest.js
+++ b/boilerplate/Tests/Components/DrawerButtonTest.js
@@ -1,18 +1,12 @@
-// https://github.com/airbnb/enzyme/blob/master/docs/api/shallow.md
+import 'react-native'
 import React from 'react'
 import DrawerButton from '../../App/Components/DrawerButton'
 import { shallow } from 'enzyme'
+import renderer from 'react-test-renderer'
 
-const wrapper = shallow(<DrawerButton onPress={() => {}} text='hi' />)
-
-test('component exists', () => {
-  expect(wrapper.length).toBe(1) // exists
-})
-
-test('component structure', () => {
-  expect(wrapper.name()).toBe('TouchableOpacity') // the right root component
-  expect(wrapper.children().length).toBe(1) // has 1 child
-  expect(wrapper.children().first().name()).toBe('Text') // that child is Text
+test('AlertMessage component renders correctly', () => {
+  const tree = renderer.create(<DrawerButton onPress={() => {}} text='hi' />).toJSON()
+  expect(tree).toMatchSnapshot()
 })
 
 test('onPress', () => {

--- a/boilerplate/Tests/Components/FullButtonTest.js
+++ b/boilerplate/Tests/Components/FullButtonTest.js
@@ -1,19 +1,12 @@
-// https://github.com/airbnb/enzyme/blob/master/docs/api/shallow.md
+import 'react-native'
 import React from 'react'
 import FullButton from '../../App/Components/FullButton'
 import { shallow } from 'enzyme'
+import renderer from 'react-test-renderer'
 
-// Basic wrapper
-const wrapper = shallow(<FullButton onPress={() => {}} text='hi' />)
-
-test('component exists', () => {
-  expect(wrapper.length).toBe(1) // exists
-})
-
-test('component structure', () => {
-  expect(wrapper.name()).toBe('TouchableOpacity') // the right root component
-  expect(wrapper.children().length).toBe(1) // has 1 child
-  expect(wrapper.children().first().name()).toBe('Text') // that child is Text
+test('FullButton component renders correctly', () => {
+  const tree = renderer.create(<FullButton onPress={() => {}} text='hi' />).toJSON()
+  expect(tree).toMatchSnapshot()
 })
 
 test('onPress', () => {
@@ -26,3 +19,4 @@ test('onPress', () => {
   wrapperPress.simulate('press')
   expect(i).toBe(1)
 })
+

--- a/boilerplate/Tests/Components/RoundedButtonTest.js
+++ b/boilerplate/Tests/Components/RoundedButtonTest.js
@@ -1,23 +1,17 @@
-// https://github.com/airbnb/enzyme/blob/master/docs/api/shallow.md
+import 'react-native'
 import React from 'react'
 import RoundedButton from '../../App/Components/RoundedButton'
 import { shallow } from 'enzyme'
+import renderer from 'react-test-renderer'
 
-// Basic wrapper
-const wrapper = shallow(<RoundedButton onPress={() => {}} text='howdy' />)
-
-test('component exists', () => {
-  expect(wrapper.length).toBe(1) // exists
+test('RoundedButton component renders correctly', () => {
+  const tree = renderer.create(<RoundedButton onPress={() => {}} text='howdy' />).toJSON()
+  expect(tree).toMatchSnapshot()
 })
 
-test('component structure', () => {
-  expect(wrapper.name()).toBe('TouchableOpacity') // the right root component
-  expect(wrapper.children().length).toBe(1) // has 1 child
-  expect(wrapper.children().first().name()).toBe('Text') // that child is Text
-})
-
-test('the text is set properly - uppercase', () => {
-  expect(wrapper.children().first().props().children).toBe('HOWDY')
+test('RoundedButton component with children renders correctly', () => {
+  const tree = renderer.create(<RoundedButton onPress={() => {}}>Howdy</RoundedButton>).toJSON()
+  expect(tree).toMatchSnapshot()
 })
 
 test('onPress', () => {
@@ -31,8 +25,3 @@ test('onPress', () => {
   expect(i).toBe(1)
 })
 
-test('renders children text when passed', () => {
-  const wrapperChild = shallow(<RoundedButton onPress={() => {}}>Howdy</RoundedButton>)
-  expect(wrapperChild.children().length).toBe(1) // has 1 child
-  expect(wrapperChild.children().first().name()).toBe('Text') // that child is Text
-})

--- a/boilerplate/Tests/Redux/LoginReduxTest.js
+++ b/boilerplate/Tests/Redux/LoginReduxTest.js
@@ -1,4 +1,4 @@
-import Actions, { reducer, INITIAL_STATE } from '../../App/Redux/LoginRedux'
+import Actions, { reducer, INITIAL_STATE, isLoggedIn } from '../../App/Redux/LoginRedux'
 
 test('attempt', () => {
   const state = reducer(INITIAL_STATE, Actions.loginRequest('u', 'p'))
@@ -24,4 +24,10 @@ test('logout', () => {
   const state = reducer(loginState, Actions.logout())
 
   expect(state.username).toBeFalsy()
+})
+
+test('isLoggedIn', () => {
+  const state = reducer(INITIAL_STATE, Actions.loginSuccess('hi'))
+
+  expect(isLoggedIn(state)).toBe(true)
 })

--- a/boilerplate/Tests/Services/FixtureAPITest.js
+++ b/boilerplate/Tests/Services/FixtureAPITest.js
@@ -11,3 +11,30 @@ test('All fixtures map to actual API', () => {
   // There is no difference between the intersection and all fixtures
   expect(R.equals(fixtureKeys, intersection)).toBe(true)
 })
+
+test('FixtureAPI getRate returns the right file', () => {
+  const expectedFile = require('../../App/Fixtures/rateLimit.json')
+
+  expect(FixtureAPI.getRate()).toEqual({
+    ok: true,
+    data: expectedFile
+  })
+})
+
+test('FixtureAPI getUser returns the right file for gantman', () => {
+  const expectedFile = require('../../App/Fixtures/gantman.json')
+
+  expect(FixtureAPI.getUser('GantMan')).toEqual({
+    ok: true,
+    data: expectedFile
+  })
+})
+
+test('FixtureAPI getUser returns the right file for skellock as default', () => {
+  const expectedFile = require('../../App/Fixtures/skellock.json')
+
+  expect(FixtureAPI.getUser('Whatever')).toEqual({
+    ok: true,
+    data: expectedFile
+  })
+})

--- a/boilerplate/Tests/Setup.js.ejs
+++ b/boilerplate/Tests/Setup.js.ejs
@@ -1,59 +1,25 @@
-import mockery from 'mockery'
-import m from 'module'
+jest
+.mock('react-native-device-info', () => {
+  return { isTablet: jest.fn(() => { return false }) }
+})
 <%_ if (props.i18n === 'react-native-i18n') { _%>
-import english from '../App/I18n/languages/english.json'
-import {keys, replace, forEach} from 'ramda'
-<%_ } _%>
+.mock('react-native-i18n', () => {
+  const english = require('../App/I18n/languages/english.json')
+  const keys = require('ramda')
+  const replace = require('ramda')
+  const forEach = require('ramda')
 
-// inject __DEV__ as it is not available when running through the tests
-global.__DEV__ = true
+  return {
+    t: (key, replacements) => {
+      let value = english[key]
+      if (!value) return key
+      if (!replacements) return value
 
-// We enable mockery and leave it on.
-mockery.enable()
-
-// Silence the warnings when *real* modules load... this is a change from
-// the norm.  We want to opt-in instead of opt-out because not everything
-// will be mocked.
-mockery.warnOnUnregistered(false)
-
-// Mock any libs that get called in here
-// I'm looking at you react-native-router-flux, reactotron etc!
-mockery.registerMock('reactotron-react-native', {})
-mockery.registerMock('reactotron-redux', {})
-mockery.registerMock('reactotron-apisauce', {})
-<%_ if (props.animatable === 'react-native-animatable') { _%>
-mockery.registerMock('react-native-animatable', {View: 'Animatable.View'})
-<%_ } _%>
-<%_ if (props.vectorIcons === 'react-native-vector-icons') { _%>
-mockery.registerMock('react-native-vector-icons/Ionicons', {})
-<%_ } _%>
-mockery.registerMock('react-native-router-flux', {Actions: {'myScreen': () => {}}, ActionConst: {RESET: 'reset'}})
-
-<%_ if (props.i18n === 'react-native-i18n') { _%>
-// Mock i18n as it uses react native stuff
-// This mock returns the interpolated text from the english.json file in App/I18n
-// If you are not using '../App/I18n/english.json' for your I18n values, simply replace import english
-// with the import at the top of this file from '../App/I18n/english.json' with the I18n json file you
-// want to use, such as "import french from '../App/I18n/fr.json'" and set 'let value = french[key]`
-mockery.registerMock('react-native-i18n', {
-  t: (key, replacements) => {
-    let value = english[key]
-    if (!value) return key
-    if (!replacements) return value
-
-    forEach((r) => {
-      value = replace(`{{${r}}}`, replacements[r], value)
-    }, keys(replacements))
-    return value
+      forEach((r) => {
+        value = replace(`{{${r}}}`, replacements[r], value)
+      }, keys(replacements))
+      return value
+    }
   }
 })
 <%_ } _%>
-// Mock all images for React Native
-const originalLoader = m._load
-m._load = (request, parent, isMain) => {
-  if (request.match(/.jpeg|.jpg|.png|.gif$/)) {
-    return { uri: request }
-  }
-
-  return originalLoader(request, parent, isMain)
-}

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -8,6 +8,7 @@
     "clean:android": "cd android/ && ./gradlew clean && cd .. && react-native run-android",
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build && rm -rf node_modules/ && npm cache clean && npm i",
     "test:watch": "jest --watch",
+    "updateSnapshot": "jest --updateSnapshot",
     "coverage": "jest --coverage && open coverage/lcov-report/index.html || xdg-open coverage/lcov-report/index.html",
     "android:build": "cd android && ./gradlew assembleRelease",
     "android:install": "cd android && ./gradlew assembleRelease && ./gradlew installRelease",
@@ -44,7 +45,6 @@
     "husky": "^0.13.1",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.4.0",
-    "react-native-mock": "^0.3.1",
     "reactotron-apisauce": "^1.7.0",
     "reactotron-react-native": "^1.7.0",
     "reactotron-redux": "^1.7.0",
@@ -62,9 +62,6 @@
       "Tests/Setup.js"
     ],
     "setupFiles": [
-      "babel-register",
-      "babel-polyfill",
-      "react-native-mock/mock",
       "./Tests/Setup"
     ],
     "preset": "react-native"
@@ -80,7 +77,8 @@
       "__DEV__",
       "XMLHttpRequest",
       "FormData",
-      "React$Element"
+      "React$Element",
+      "jest"
     ]
   },
   "config": {


### PR DESCRIPTION
This completes the conversion from Ava to Jest tests.

1. package.json.ejs: Added script to update snapshots, removed react-native-mock and setup files in the jest block that were causing memory leak errors. 

2. Tests/Setup.js.ejs re-written to use jest mocks rather than using mockery. Includes support for components and their tests that use the react-native-i18n library. 

3. Re-wrote component tests to use snapshots to replace previous tests that used Enzyme/shallow to test the generated output. Because some people might want to use Enzyme/shallow for their component tests, I left in examples that exercise 'onPress' callbacks. This also shows that the shallow component tests are still working with jest.

4. Added more tests to the boilerplate (LoginReduxTest, FixtureApiTest) to improve test coverage.

5. Added flags to ExamplesRegistry function calls in components that tells code coverage reports to ignore them

