### PR TITLE
Standard Plugin

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -186,7 +186,6 @@ async function install (context) {
         stdio: 'inherit'
       })
     }
-
   } catch (e) {
     ignite.log(e)
     throw e

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -180,6 +180,13 @@ async function install (context) {
         stdio: 'inherit'
       })
     }
+
+    if (parameters.options.lint !== 'false') {
+      await system.spawn(`ignite add standard ${debugFlag}`, {
+        stdio: 'inherit'
+      })
+    }
+
   } catch (e) {
     ignite.log(e)
     throw e

--- a/boilerplate/Tests/Components/FullButtonTest.js
+++ b/boilerplate/Tests/Components/FullButtonTest.js
@@ -19,4 +19,3 @@ test('onPress', () => {
   wrapperPress.simulate('press')
   expect(i).toBe(1)
 })
-

--- a/boilerplate/Tests/Components/RoundedButtonTest.js
+++ b/boilerplate/Tests/Components/RoundedButtonTest.js
@@ -24,4 +24,3 @@ test('onPress', () => {
   wrapperPress.simulate('press')
   expect(i).toBe(1)
 })
-

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -1,9 +1,6 @@
 {
   "version": "0.0.1",
   "scripts": {
-    "lint": "standard --verbose | snazzy",
-    "lintdiff": "git diff --name-only --cached --relative | grep '\\.js$' | xargs standard | snazzy",
-    "fixcode": "standard --fix",
     "clean": "rm -rf $TMPDIR/react-* && watchman watch-del-all && npm cache clean",
     "clean:android": "cd android/ && ./gradlew clean && cd .. && react-native run-android",
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build && rm -rf node_modules/ && npm cache clean && npm i",
@@ -18,7 +15,7 @@
     "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
     "precommit": "npm run git-hook",
     "prepush": "npm run git-hook",
-    "git-hook": "npm run lint -s && npm test -s"
+    "git-hook": "npm test -s"
   },
   "dependencies": {
     "apisauce": "^0.10.0",
@@ -38,7 +35,6 @@
     "seamless-immutable": "^7.0.1"
   },
   "devDependencies": {
-    "babel-eslint": "^7.1.1",
     "babel-preset-es2015": "^6.18.0",
     "enzyme": "^2.6.0",
     "mockery": "^2.0.0",
@@ -48,9 +44,7 @@
     "reactotron-apisauce": "^1.7.0",
     "reactotron-react-native": "^1.7.0",
     "reactotron-redux": "^1.7.0",
-    "reactotron-redux-saga": "^1.7.0",
-    "snazzy": "^6.0.0",
-    "standard": "8.6.0"
+    "reactotron-redux-saga": "^1.7.0"
   },
   "jest": {
     "testMatch": [
@@ -66,24 +60,5 @@
     ],
     "preset": "react-native"
   },
-  "standard": {
-    "parser": "babel-eslint",
-    "globals": [
-      "describe",
-      "test",
-      "expect",
-      "fetch",
-      "navigator",
-      "__DEV__",
-      "XMLHttpRequest",
-      "FormData",
-      "React$Element",
-      "jest"
-    ]
-  },
-  "config": {
-    "ghooks": {
-      "pre-commit": "if [ -d 'ignite-base' ]; then cd ignite-base; fi; npm run lint"
-    }
-  }
+  "config": {}
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
       "beforeAll",
       "afterAll",
       "test",
-      "expect"
+      "expect",
+      "describe"
     ]
   },
   "devDependencies": {

--- a/templates/component.ejs
+++ b/templates/component.ejs
@@ -3,7 +3,6 @@ import { View, Text } from 'react-native'
 import styles from './Styles/<%= props.name %>Style'
 
 export default class <%= props.name %> extends React.Component {
-
   render () {
     return (
       <View style={styles.container}>

--- a/templates/container.ejs
+++ b/templates/container.ejs
@@ -8,7 +8,6 @@ import { connect } from 'react-redux'
 import styles from './Styles/<%= props.name %>Style'
 
 class <%= props.name %> extends React.Component {
-
   // constructor (props) {
   //   super(props)
   //   this.state = {}

--- a/templates/examples/GridExample.js.ejs
+++ b/templates/examples/GridExample.js.ejs
@@ -10,7 +10,6 @@ import { connect } from 'react-redux'
 import styles from './Styles/GridExampleStyle'
 
 class GridExample extends React.Component {
-
   constructor (props) {
     super(props)
     // If you need scroll to bottom, consider http://bit.ly/2bMQ2BZ

--- a/templates/examples/RowExample.js.ejs
+++ b/templates/examples/RowExample.js.ejs
@@ -6,7 +6,6 @@ import { connect } from 'react-redux'
 import styles from './Styles/RowExampleStyle'
 
 class RowExample extends React.Component {
-
   constructor (props) {
     super(props)
     // If you need scroll to bottom, consider http://bit.ly/2bMQ2BZ

--- a/templates/examples/SectionExample.js.ejs
+++ b/templates/examples/SectionExample.js.ejs
@@ -6,7 +6,6 @@ import { connect } from 'react-redux'
 import styles from './Styles/SectionExampleStyle'
 
 class ListviewSectionsExample extends React.Component {
-
   constructor (props) {
     super(props)
 

--- a/templates/listview-sections.ejs
+++ b/templates/listview-sections.ejs
@@ -9,7 +9,6 @@ import { connect } from 'react-redux'
 import styles from './Styles/<%= props.name %>Style'
 
 class ListviewSectionsExample extends React.Component {
-
   constructor (props) {
     super(props)
 

--- a/templates/listview.ejs
+++ b/templates/listview.ejs
@@ -9,7 +9,6 @@ import { connect } from 'react-redux'
 import styles from './Styles/<%= props.name %>Style'
 
 class <%= props.name %> extends React.Component {
-
   state: {
     dataSource: Object
   }

--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -8,7 +8,6 @@ import { connect } from 'react-redux'
 import styles from './Styles/<%= props.name %>ScreenStyle'
 
 class <%= props.name %>Screen extends React.Component {
-
   render () {
     return (
       <ScrollView style={styles.container}>
@@ -18,7 +17,6 @@ class <%= props.name %>Screen extends React.Component {
       </ScrollView>
     )
   }
-
 }
 
 const mapStateToProps = (state) => {

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -7,75 +7,94 @@ const APP = 'IntegrationTest'
 // calling the ignite cli takes a while
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000
 
-beforeAll(async () => {
-  jetpack.remove(APP)
-  await execa(IGNITE, ['new', APP, '--min', '--skip-git', '--boilerplate', `${__dirname}/..`])
-  process.chdir(APP)
+describe('without a linter', () => {
+  beforeAll(async () => {
+    jetpack.remove(APP)
+    await execa(IGNITE, ['new', APP, '--min', '--skip-git', '--no-lint', '--boilerplate', `${__dirname}/..`])
+    process.chdir(APP)
+  })
+
+  afterAll(() => {
+    process.chdir('../')
+    jetpack.remove(APP)
+  })
+
+  test('does not have a linting script', async () => {
+    expect(jetpack.read('package.json', 'json')['scripts']['lint']).toBe(undefined)
+  })
 })
 
-afterAll(() => {
-  process.chdir('../')
-  jetpack.remove(APP)
-})
+describe('generators', () => {
+  beforeAll(async () => {
+    jetpack.remove(APP)
+    await execa(IGNITE, ['new', APP, '--min', '--skip-git', '--boilerplate', `${__dirname}/..`])
+    process.chdir(APP)
+  })
 
-test('generates a component', async () => {
-  await execa(IGNITE, ['g', 'component', 'Test'], { preferLocal: false })
-  expect(jetpack.exists('App/Components/Test.js')).toBe('file')
-  expect(jetpack.exists('App/Components/Styles/TestStyle.js')).toBe('file')
-  const lint = await execa('npm', ['-s', 'run', 'lint'])
-  expect(lint.stderr).toBe('')
-})
+  afterAll(() => {
+    process.chdir('../')
+    jetpack.remove(APP)
+  })
 
-test('generate listview of type row works', async () => {
-  await execa(IGNITE, ['g', 'listview', 'TestRow', '--type=Row'], { preferLocal: false })
-  expect(jetpack.exists('App/Containers/TestRow.js')).toBe('file')
-  expect(jetpack.exists('App/Containers/Styles/TestRowStyle.js')).toBe('file')
-  const lint = await execa('npm', ['run', 'lint'])
-  expect(lint.stderr).toBe('')
-})
+  test('generates a component', async () => {
+    await execa(IGNITE, ['g', 'component', 'Test'], { preferLocal: false })
+    expect(jetpack.exists('App/Components/Test.js')).toBe('file')
+    expect(jetpack.exists('App/Components/Styles/TestStyle.js')).toBe('file')
+    const lint = await execa('npm', ['-s', 'run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 
-test('generate listview of type sections works', async () => {
-  await execa(IGNITE, ['g', 'listview', 'TestSection', '--type=WithSections'], { preferLocal: false })
-  expect(jetpack.exists('App/Containers/TestSection.js')).toBe('file')
-  expect(jetpack.exists('App/Containers/Styles/TestSectionStyle.js')).toBe('file')
-  const lint = await execa('npm', ['run', 'lint'])
-  expect(lint.stderr).toBe('')
-})
+  test('generate listview of type row works', async () => {
+    await execa(IGNITE, ['g', 'listview', 'TestRow', '--type=Row'], { preferLocal: false })
+    expect(jetpack.exists('App/Containers/TestRow.js')).toBe('file')
+    expect(jetpack.exists('App/Containers/Styles/TestRowStyle.js')).toBe('file')
+    const lint = await execa('npm', ['run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 
-test('generate listview of type grid works', async () => {
-  await execa(IGNITE, ['g', 'listview', 'TestGrid', '--type=Grid'], { preferLocal: false })
-  expect(jetpack.exists('App/Containers/TestGrid.js')).toBe('file')
-  expect(jetpack.exists('App/Containers/Styles/TestGridStyle.js')).toBe('file')
-  const lint = await execa('npm', ['run', 'lint'])
-  expect(lint.stderr).toBe('')
-})
+  test('generate listview of type sections works', async () => {
+    await execa(IGNITE, ['g', 'listview', 'TestSection', '--type=WithSections'], { preferLocal: false })
+    expect(jetpack.exists('App/Containers/TestSection.js')).toBe('file')
+    expect(jetpack.exists('App/Containers/Styles/TestSectionStyle.js')).toBe('file')
+    const lint = await execa('npm', ['run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 
-test('generate redux works', async () => {
-  await execa(IGNITE, ['g', 'redux', 'Test'], { preferLocal: false })
-  expect(jetpack.exists('App/Redux/TestRedux.js')).toBe('file')
-  const lint = await execa('npm', ['run', 'lint'])
-  expect(lint.stderr).toBe('')
-})
+  test('generate listview of type grid works', async () => {
+    await execa(IGNITE, ['g', 'listview', 'TestGrid', '--type=Grid'], { preferLocal: false })
+    expect(jetpack.exists('App/Containers/TestGrid.js')).toBe('file')
+    expect(jetpack.exists('App/Containers/Styles/TestGridStyle.js')).toBe('file')
+    const lint = await execa('npm', ['run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 
-test('generate container works', async () => {
-  await execa(IGNITE, ['g', 'container', 'Container'], { preferLocal: false })
-  expect(jetpack.exists('App/Containers/Container.js')).toBe('file')
-  expect(jetpack.exists('App/Containers/Styles/ContainerStyle.js')).toBe('file')
-  const lint = await execa('npm', ['run', 'lint'])
-  expect(lint.stderr).toBe('')
-})
+  test('generate redux works', async () => {
+    await execa(IGNITE, ['g', 'redux', 'Test'], { preferLocal: false })
+    expect(jetpack.exists('App/Redux/TestRedux.js')).toBe('file')
+    const lint = await execa('npm', ['run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 
-test('generate saga works', async () => {
-  await execa(IGNITE, ['g', 'saga', 'Test'], { preferLocal: false })
-  expect(jetpack.exists('App/Sagas/TestSagas.js')).toBe('file')
-  const lint = await execa('npm', ['run', 'lint'])
-  expect(lint.stderr).toBe('')
-})
+  test('generate container works', async () => {
+    await execa(IGNITE, ['g', 'container', 'Container'], { preferLocal: false })
+    expect(jetpack.exists('App/Containers/Container.js')).toBe('file')
+    expect(jetpack.exists('App/Containers/Styles/ContainerStyle.js')).toBe('file')
+    const lint = await execa('npm', ['run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 
-test('generate screen works', async () => {
-  await execa(IGNITE, ['g', 'screen', 'Test'], { preferLocal: false })
-  expect(jetpack.exists('App/Containers/TestScreen.js')).toBe('file')
-  expect(jetpack.exists('App/Containers/Styles/TestScreenStyle.js')).toBe('file')
-  const lint = await execa('npm', ['run', 'lint'])
-  expect(lint.stderr).toBe('')
+  test('generate saga works', async () => {
+    await execa(IGNITE, ['g', 'saga', 'Test'], { preferLocal: false })
+    expect(jetpack.exists('App/Sagas/TestSagas.js')).toBe('file')
+    const lint = await execa('npm', ['run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
+
+  test('generate screen works', async () => {
+    await execa(IGNITE, ['g', 'screen', 'Test'], { preferLocal: false })
+    expect(jetpack.exists('App/Containers/TestScreen.js')).toBe('file')
+    expect(jetpack.exists('App/Containers/Styles/TestScreenStyle.js')).toBe('file')
+    const lint = await execa('npm', ['run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 })


### PR DESCRIPTION
This removes Standard and other linting dependencies to make way for Standard to be installed as a plugin. 

https://github.com/infinitered/ignite-ir-next/issues/47

Removes `standard`, `babel-eslint`, `snazzy`, linting scripts and configuration from `package.json`
Adds a step to boilerplate install which installs standard from npm (https://github.com/robinheinze/ignite-standard) ...(NOTE: this shouldn't be merged until that plugin has been published to npm)

`ignite new` can be run with a `--no-lint` option to not install any linter at all. 

Updates integration tests and fixes a few instances of padded blocks that were being called out by Standard 10.0.2. 