### PR TITLE
Updates Reactotron to the latest version & techniques.

### DIFF
--- a/boilerplate/App/Config/ReactotronConfig.js
+++ b/boilerplate/App/Config/ReactotronConfig.js
@@ -1,4 +1,3 @@
-// import { StartupTypes } from '../Redux/StartupRedux'
 import Config from '../Config/DebugConfig'
 import Immutable from 'seamless-immutable'
 import Reactotron from 'reactotron-react-native'
@@ -6,42 +5,12 @@ import { reactotronRedux as reduxPlugin } from 'reactotron-redux'
 import sagaPlugin from 'reactotron-redux-saga'
 
 if (Config.useReactotron) {
+  // https://github.com/infinitered/reactotron for more options!
   Reactotron
-    // configure how & where to talk to the Desktop App
-    .configure({
-      // host: '10.0.3.2' // default is localhost (on android don't forget to `adb reverse tcp:9090 tcp:9090`)
-      name: 'Ignite App' // would you like to see your app's name?,
-      // safeRecursion: false  // ADVANCED: default is true (turning off will bypass reactotron's safety checks for serialization)
-    })
-
-    // register all React Native features - with default settings
-    .useReactNative(
-      // {
-      //   overlay: {},
-      //   errors: {},
-      //   asyncStorage: {},
-      //   networking: {},
-      //   editor: {}
-      // }
-    )
-
-    // register the Redux plugin -- checkout /App/Redux/CreateStore.js to see how it is used.
-    .use(reduxPlugin({
-      // you can flag some of your actions as important by returning true here
-      // isActionImportant: action => action.type === StartupTypes.STARTUP,
-
-      // you can flag to exclude certain types too... especially the chatty ones
-      // except: ['EFFECT_TRIGGERED', 'EFFECT_RESOLVED', 'EFFECT_REJECTED', 'persist/REHYDRATE'],
-
-      // Fires when Reactotron uploads a new copy of the state tree.  Since our reducers are
-      // immutable with `seamless-immutable`, we ensure we convert to that format.
-      onRestore: state => Immutable(state)
-    }))
-
-    // register the redux-saga plugin so we can use the monitor in CreateStore.js
+    .configure({ name: 'Ignite App' })
+    .useReactNative()
+    .use(reduxPlugin({ onRestore: Immutable }))
     .use(sagaPlugin())
-
-    // let's connect!
     .connect()
 
   // Let's clear Reactotron on every time we load the app
@@ -50,13 +19,4 @@ if (Config.useReactotron) {
   // Totally hacky, but this allows you to not both importing reactotron-react-native
   // on every file.  This is just DEV mode, so no big deal.
   console.tron = Reactotron
-} else {
-  // a mock version should you decide to leave console.tron in your codebase
-  console.tron = {
-    log: () => false,
-    warn: () => false,
-    error: () => false,
-    display: () => false,
-    image: () => false
-  }
 }

--- a/boilerplate/App/Config/ReactotronConfig.js
+++ b/boilerplate/App/Config/ReactotronConfig.js
@@ -1,35 +1,34 @@
-import { StartupTypes } from '../Redux/StartupRedux'
+// import { StartupTypes } from '../Redux/StartupRedux'
 import Config from '../Config/DebugConfig'
 import Immutable from 'seamless-immutable'
-import Reactotron, { overlay, trackGlobalErrors } from 'reactotron-react-native'
-import apisaucePlugin from 'reactotron-apisauce'
-import { reactotronRedux } from 'reactotron-redux'
+import Reactotron from 'reactotron-react-native'
+import { reactotronRedux as reduxPlugin } from 'reactotron-redux'
 import sagaPlugin from 'reactotron-redux-saga'
 
 if (Config.useReactotron) {
   Reactotron
+    // configure how & where to talk to the Desktop App
     .configure({
       // host: '10.0.3.2' // default is localhost (on android don't forget to `adb reverse tcp:9090 tcp:9090`)
-      name: 'Ignite App' // would you like to see your app's name?
+      name: 'Ignite App' // would you like to see your app's name?,
+      // safeRecursion: false  // ADVANCED: default is true (turning off will bypass reactotron's safety checks for serialization)
     })
 
-    // forward all errors to Reactotron
-    .use(trackGlobalErrors({
-      // ignore all error frames from react-native (for example)
-      veto: (frame) =>
-        frame.fileName.indexOf('/node_modules/react-native/') >= 0
-    }))
+    // register all React Native features - with default settings
+    .useReactNative(
+      // {
+      //   overlay: {},
+      //   errors: {},
+      //   asyncStorage: {},
+      //   networking: {},
+      //   editor: {}
+      // }
+    )
 
-    // register apisauce so we can install a monitor later
-    .use(apisaucePlugin())
-
-    // add overlay ability for graphics
-    .use(overlay())
-
-    // setup the redux integration with Reactotron
-    .use(reactotronRedux({
+    // register the Redux plugin -- checkout /App/Redux/CreateStore.js to see how it is used.
+    .use(reduxPlugin({
       // you can flag some of your actions as important by returning true here
-      isActionImportant: action => action.type === StartupTypes.STARTUP,
+      // isActionImportant: action => action.type === StartupTypes.STARTUP,
 
       // you can flag to exclude certain types too... especially the chatty ones
       // except: ['EFFECT_TRIGGERED', 'EFFECT_RESOLVED', 'EFFECT_REJECTED', 'persist/REHYDRATE'],

--- a/boilerplate/App/Containers/App.js
+++ b/boilerplate/App/Containers/App.js
@@ -26,7 +26,7 @@ class App extends Component {
   }
 }
 
-// allow reactotron overlay for fast design
-const AppWithBenefits = console.tron.overlay(App)
+// allow reactotron overlay for fast design in dev mode
+const AppWithBenefits = __DEV__ ? console.tron.overlay(App) : App
 
 export default AppWithBenefits

--- a/boilerplate/App/Containers/App.js
+++ b/boilerplate/App/Containers/App.js
@@ -1,4 +1,5 @@
 import '../Config'
+import DebugConfig from '../Config/DebugConfig'
 import React, { Component } from 'react'
 import { Provider } from 'react-redux'
 import RootContainer from './RootContainer'
@@ -27,6 +28,6 @@ class App extends Component {
 }
 
 // allow reactotron overlay for fast design in dev mode
-const AppWithBenefits = __DEV__ ? console.tron.overlay(App) : App
-
-export default AppWithBenefits
+export default DebugConfig.useReactotron
+  ? console.tron.overlay(App)
+  : App

--- a/boilerplate/App/Redux/CreateStore.js
+++ b/boilerplate/App/Redux/CreateStore.js
@@ -14,7 +14,7 @@ export default (rootReducer, rootSaga) => {
 
   /* ------------- Saga Middleware ------------- */
 
-  const sagaMonitor = __DEV__ ? console.tron.createSagaMonitor() : null
+  const sagaMonitor = Config.useReactotron ? console.tron.createSagaMonitor() : null
   const sagaMiddleware = createSagaMiddleware({ sagaMonitor })
   middleware.push(sagaMiddleware)
 

--- a/boilerplate/App/Services/Api.js
+++ b/boilerplate/App/Services/Api.js
@@ -20,13 +20,6 @@ const create = (baseURL = 'https://api.github.com/') => {
     timeout: 10000
   })
 
-  // Wrap api's addMonitor to allow the calling code to attach
-  // additional monitors in the future.  But only in __DEV__ and only
-  // if we've attached Reactotron to console (it isn't during unit tests).
-  if (__DEV__ && console.tron) {
-    api.addMonitor(console.tron.apisauce)
-  }
-
   // ------
   // STEP 2
   // ------

--- a/boilerplate/App/Services/RehydrationServices.js
+++ b/boilerplate/App/Services/RehydrationServices.js
@@ -2,6 +2,7 @@ import ReduxPersist from '../Config/ReduxPersist'
 import { AsyncStorage } from 'react-native'
 import { persistStore } from 'redux-persist'
 import StartupActions from '../Redux/StartupRedux'
+import DebugConfig from '../Config/DebugConfig'
 
 const updateReducers = (store: Object) => {
   const reducerVersion = ReduxPersist.reducerVersion
@@ -11,15 +12,17 @@ const updateReducers = (store: Object) => {
   // Check to ensure latest reducer version
   AsyncStorage.getItem('reducerVersion').then((localVersion) => {
     if (localVersion !== reducerVersion) {
-      console.tron.display({
-        name: 'PURGE',
-        value: {
-          'Old Version:': localVersion,
-          'New Version:': reducerVersion
-        },
-        preview: 'Reducer Version Change Detected',
-        important: true
-      })
+      if (DebugConfig.useReactotron) {
+        console.tron.display({
+          name: 'PURGE',
+          value: {
+            'Old Version:': localVersion,
+            'New Version:': reducerVersion
+          },
+          preview: 'Reducer Version Change Detected',
+          important: true
+        })
+      }
       // Purge store
       persistStore(store, config, startup).purge()
       AsyncStorage.setItem('reducerVersion', reducerVersion)

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -41,10 +41,9 @@
     "husky": "^0.13.1",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.4.0",
-    "reactotron-apisauce": "^1.7.0",
-    "reactotron-react-native": "^1.7.0",
-    "reactotron-redux": "^1.7.0",
-    "reactotron-redux-saga": "^1.7.0"
+    "reactotron-react-native": "^1.11.1",
+    "reactotron-redux": "^1.11.1",
+    "reactotron-redux-saga": "^1.11.1"
   },
   "jest": {
     "testMatch": [


### PR DESCRIPTION
This also fixes the issue of trying to use the Reactotron Overlay in production.

A few new features since 1.7:

* `reactotron-apisauce` is no longer needed.  we place our hooks at the `XMLHTTPRequest` level, so all networking requests are supported.  :tada:
* `AsyncStorage` is now tracked
* nicer serialization (we now can track falsy values and better circular dependency detection)

Fixes #49